### PR TITLE
Adjust navigation spacing and layout

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -62,7 +62,7 @@ export function Navigation() {
             className="h-8 w-auto"
           />
         </a>
-        <ul className="flex items-center gap-4 overflow-x-auto text-xs md:gap-6 md:text-sm">
+        <ul className="flex flex-wrap items-center gap-6 text-xs md:gap-8 md:text-sm">
           {navigationLinks.map((link) => (
             <li key={link.id}>
               <a


### PR DESCRIPTION
## Summary
- increase spacing between navigation links for improved readability
- allow the menu to wrap naturally and remove horizontal scrollbar

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d29cb704308326a73f59d817c2cc12