### PR TITLE
Adjust navigation spacing and remove scrollbar

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -62,13 +62,13 @@ export function Navigation() {
             className="h-8 w-auto"
           />
         </a>
-        <ul className="flex items-center gap-4 overflow-x-auto text-xs md:gap-6 md:text-sm">
+        <ul className="flex flex-wrap items-center gap-5 text-xs md:gap-7 md:text-sm">
           {navigationLinks.map((link) => (
             <li key={link.id}>
               <a
                 href={link.href}
                 onClick={(event) => handleNavClick(event, link.href)}
-                className="font-poppins font-medium text-white transition-colors duration-200 hover:text-emerald-400"
+                className="px-2 font-poppins font-medium text-white transition-colors duration-200 hover:text-emerald-400 md:px-3"
                 rel={isExternalLink(link.href) ? 'noreferrer noopener' : undefined}
                 target={isExternalLink(link.href) ? '_blank' : undefined}
               >


### PR DESCRIPTION
## Summary
- increase spacing between navigation links so the menu feels less cramped
- add internal padding to each link for a larger click target
- remove horizontal overflow to eliminate the scrollbar while allowing wrapping

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d29f5a2f208326b517a73f5e835ee3