### PR TITLE
Adjust navigation spacing and wrap

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -62,7 +62,7 @@ export function Navigation() {
             className="h-8 w-auto"
           />
         </a>
-        <ul className="flex items-center gap-4 overflow-x-auto text-xs md:gap-6 md:text-sm">
+        <ul className="flex flex-1 flex-wrap items-center justify-center gap-5 text-xs md:flex-nowrap md:gap-8 md:text-sm">
           {navigationLinks.map((link) => (
             <li key={link.id}>
               <a


### PR DESCRIPTION
## Summary
- increase spacing between navigation links for better breathing room
- allow navigation items to wrap and center so the scrollbar is no longer visible

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d29f5a2f208326b517a73f5e835ee3